### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluentd plugin for td monitoring
+# [Fluentd](http://fluentd.org) plugin for td monitoring
 
 # Getting Started
 


### PR DESCRIPTION
Hello, I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.