### PR TITLE
Fix gem version to support ruby 2.1

### DIFF
--- a/fluent-plugin-td-monitoring.gemspec
+++ b/fluent-plugin-td-monitoring.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency "fluentd", ">= 0.10.33"
+  gem.add_dependency "mixlib-cli", "~> 1.7.0"
+  gem.add_dependency "mixlib-config", "~> 2.2.4"
+  gem.add_dependency "mixlib-log", "~> 1.7.1"
+  gem.add_dependency "mixlib-shellout", "~> 2.2.7"
   gem.add_dependency "ohai", "~> 6.20.0"
   gem.add_dependency "httpclient", "~> 2.7"
   gem.add_development_dependency "rake", ">= 0.9.2"


### PR DESCRIPTION
Latest `mixlib-shellout` drop ruby 2.1 support.